### PR TITLE
Add cancellable processing and progress bar to ShinyQC

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,6 +21,7 @@ Imports:
     fs,
     furrr,
     future,
+    promises,
     plotly,
     shinyFiles
 Suggests: 

--- a/R/ui.R
+++ b/R/ui.R
@@ -20,7 +20,10 @@ shiny::fluidPage(
                    shinyFiles::shinyDirButton("result_dir", "Result Directory", "Select a directory to save the results"),
                    shiny::verbatimTextOutput("result_dir"),
                    shiny::textInput("file_pattern", "File Pattern", value = "_[12]" ),
-                   shiny::actionButton("runButton", "Run Rfastp (Paired-end Mode)")
+                   shiny::actionButton("runButton", "Run Rfastp (Paired-end Mode)"),
+                   shinyjs::hidden(
+                     shiny::actionButton("cancelButton", "Cancel Processing")
+                   )
                    #,
                    # Area of logs
                    # uiOutput("dynamicSizeLogOutput")


### PR DESCRIPTION
## Summary
- Allow the Shiny interface to cancel running `furrr` tasks safely via `future::cancel`
- Show a new **Cancel Processing** button only while jobs are running
- Track the running future, display progress counts, and clean up UI state after completion or cancellation

## Testing
- `R --vanilla -q -e 'parse("R/server.R"); parse("R/ui.R")'`
- `R --vanilla -q -e 'devtools::test()'` *(fails: there is no package called 'devtools')*

------
https://chatgpt.com/codex/tasks/task_e_6896abddfd5c833187cde0b657f117e8